### PR TITLE
New configuration files for OSX / MacPorts

### DIFF
--- a/Makefile.defs.osx-macports
+++ b/Makefile.defs.osx-macports
@@ -1,0 +1,64 @@
+# -*- sh -*-
+##############################################################################
+#
+#  KPP - The Kinetic PreProcessor
+#        Builds simulation code for chemical kinetic systems
+#
+#  Copyright (C) 1995-1997 Valeriu Damian and Adrian Sandu
+#  Copyright (C) 1997-2005 Adrian Sandu
+#
+#  KPP is free software; you can redistribute it and/or modify it under the
+#  terms of the GNU General Public License as published by the Free Software
+#  Foundation (http://www.gnu.org/copyleft/gpl.html); either version 2 of the
+#  License, or (at your option) any later version.
+#
+#  KPP is distributed in the hope that it will be useful, but WITHOUT ANY
+#  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+#  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+#  details.
+#
+#  You should have received a copy of the GNU General Public License along
+##  with this program; if not, consult http://www.gnu.org/copyleft/gpl.html or
+#  write to the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+#  Boston, MA  02111-1307,  USA.
+#
+#  Adrian Sandu
+#  Computer Science Department
+#  Virginia Polytechnic Institute and State University
+#  Blacksburg, VA 24060
+#  E-mail: sandu@cs.vt.edu
+#
+##############################################################################
+
+# In order to compile KPP you have to provide the following information:
+
+# 1. The name of the compiler you want to use. Normaly this 
+#    is either GNU C compiler (gcc) or the native compiler (cc)
+#    You can use the complete pathname if the compiler is not in $PATH 
+#    Note that for SUN machines is better to use gcc.
+#    For GNU C compiler use:
+#      CC=gcc
+#    For the native compiler use:
+#      CC=cc
+
+CC=gcc-mp-4.9
+
+# 2. The name of your lexical analizer. KPP requires FLEX to be used.
+#    FLEX is a public domain lexical analizer and you can download it from
+#    http://www.gnu.org/software/flex/ or any other mirror site. If flex
+#    directory is not included in your path use the complete pathname.
+
+FLEX=flex
+
+# 3. The complete pathname of the FLEX library (libfl.a).
+#    On many systems this is: /usr/local/util/lib/flex
+
+FLEX_LIB_DIR=/opt/local/lib
+
+# 4. Platform independent C compiler flags. By default "-O" is used which 
+#    turns on optimisation. If you are experiencing problems you may try 
+#    "-g" to include debuging informations.
+
+CC_FLAGS=-O
+
+##############################################################################

--- a/cflags.guess.osx-macports
+++ b/cflags.guess.osx-macports
@@ -1,0 +1,42 @@
+#!/bin/sh
+UNAME_MACHINE=`(uname -m) 2>/dev/null` || UNAME_MACHINE=unknown
+UNAME_RELEASE=`(uname -r) 2>/dev/null` || UNAME_RELEASE=unknown
+UNAME_SYSTEM=`(uname -s) 2>/dev/null` || UNAME_SYSTEM=unknown
+UNAME_VERSION=`(uname -v) 2>/dev/null` || UNAME_VERSION=unknown
+echo "${UNAME_MACHINE}:${UNAME_SYSTEM}:${UNAME_RELEASE}:${UNAME_VERSION}:${CC}"
+CC=cc
+if [ x$1 != x ]; then CC=$1; fi
+
+exec 5>./cflags
+
+# Note: order is significant - the case branches are not exclusive.
+
+case "${UNAME_MACHINE}:${UNAME_SYSTEM}:${UNAME_RELEASE}:${UNAME_VERSION}:${CC}" in
+
+    *:HP-UX:*:*:cc*) # For HP-UX workstations
+        echo " -Aa -D_HPUX_SOURCE " 1>&5; exit 0 ;;
+
+    *:AIX:*:*:cc*) # For machines running AIX
+        echo " -Aa " 1>&5; exit 0 ;;
+
+    *:IRIX:*:*:cc*) # For machines running IRIX
+        echo " " 1>&5; exit 0 ;;
+
+    *:IRIX64:*:*:cc*) # For machines running IRIX64 
+        echo " " 1>&5; exit 0 ;;
+
+    *:Linux:*:*:cc*) # For Linux machines
+        echo " " 1>&5; exit 0 ;;
+
+    *:SunOS:*:*:cc*) # For SUN machines
+        echo " Please use gcc compiler on SUN machines."; exit 1 ;;
+
+    *:Darwin:*:*:gcc) # this is the default case, for gcc
+        echo "-I/opt/local/include -fbounds-check -arch i386" 1>&5; exit 0 ;;
+
+    *:*:*:*:gcc*) # this is the default case, for gcc
+        echo " " 1>&5; exit 0 ;;
+
+    *:*:*:*:*) # this is the default case
+        echo " " 1>&5; exit 0 ;;
+esac

--- a/readme.osx-macports
+++ b/readme.osx-macports
@@ -1,0 +1,29 @@
+KPP can be compiled on OSX using MacPorts (https://www.macports.org/) to supply 
+a more unix-compatible version of gcc (as well as flex). To do this follow the
+instructions below:
+
+1) Install Xcode and the Xcode Command Line Tools, and then install macports.
+See here for more guidance: https://www.macports.org/install.php
+
+2) Install Flex and GCC:
+port install gcc49
+port install flex
+
+3) Replace the Makefile.defs and cflags.guess files with the provided alternative 
+osx-macports files:
+cp Makefile.defs.osx-macports Makefile.defs
+cp cflags.guess.osx-macports cflags.guess
+
+These files are configured assuming that you've installed macports in the default,
+system-wide, location (/opt/local/). If you have installed macports anywhere else
+you will have to modify them to use your own path. Also, the gcc compiler has a
+version specific binary name - so this may need changing at a future date as new
+versions are released.
+
+
+4) Compile KPP by following the rest of the instructions in "readme".
+
+
+This installation has be tested on OSX 10.10.5, with MacPorts 2.4.2, flex 2.6.4 
+and gcc version 4.9.4. It should work with minimal changes on other OSX systems
+though.


### PR DESCRIPTION
I've created some alternative config files for OSX & MacPorts (using MacPorts makes compiling and using KPP on OSX so much simpler than trying to coerce the apple versions of gcc, etc, to work properly). There's a readme to describe how to use them, and they are separate from the original files, so wont break the usage of KPP anywhere else.